### PR TITLE
added qualcomm-smd to ANT native

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -40,6 +40,10 @@ else ifeq ($(BOARD_ANT_WIRELESS_DEVICE),"vfs-prerelease")
 
 ANT_DIR := src/vfs
 
+else ifeq ($(BOARD_ANT_WIRELESS_DEVICE),"qualcomm-smd")
+
+ANT_DIR := src/vfs
+
 else
 
 $(error Unsupported BOARD_ANT_WIRELESS_DEVICE := $(BOARD_ANT_WIRELESS_DEVICE))


### PR DESCRIPTION
Added support for "qualcomm-smd" devices that earlier caused build to fail with "Unsupported device" error.
